### PR TITLE
KaTeX export alignment bug

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,6 +24,10 @@ img {
   min-width: 0px;
 }
 
+#hiddenOutput * .katex .op-symbol.large-op {
+  top: -0.65em !important;
+}
+
 @media print {
   .hidePrint {
     display: none !important;

--- a/src/components/Files.js
+++ b/src/components/Files.js
@@ -220,7 +220,7 @@ function Files({ writing, setWriting }) {
     );
     return (
       <List className={classes.list}>
-        {files !== undefined && files.length > 0 ? (
+        {files?.length > 0 ? (
           filteredFiles?.length > 0 ? (
             filteredFiles
               .slice(0)
@@ -244,28 +244,34 @@ function Files({ writing, setWriting }) {
     );
   };
 
+  const renderSearchBar = () => {
+    return (
+      <TextField
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value.toLowerCase())}
+        className={classes.search}
+        variant="outlined"
+        placeholder="Search"
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start" className={classes.searchIcon}>
+              <SearchIcon />
+            </InputAdornment>
+          ),
+        }}
+        inputProps={{
+          className: classes.searchInput,
+        }}
+      />
+    );
+  };
+
   return (
     <>
       <Dialog open={filesDialogOpen}>
         <DialogTitle>Files</DialogTitle>
         <DialogContent>
-          <TextField
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value.toLowerCase())}
-            className={classes.search}
-            variant="outlined"
-            placeholder="Search"
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start" className={classes.searchIcon}>
-                  <SearchIcon />
-                </InputAdornment>
-              ),
-            }}
-            inputProps={{
-              className: classes.searchInput,
-            }}
-          />
+          {files?.length > 0 && renderSearchBar()}
           {renderFileList()}
         </DialogContent>
         <DialogActions>


### PR DESCRIPTION
Idk why, but KaTeX_Size2 font would be misaligned when exporting png (html2canvas). Hacky CSS fix for now.

- Only show search bar if there are files